### PR TITLE
Fix `Unknown function if` when running dealer scripts

### DIFF
--- a/src/endplay/dealer/constraint.py
+++ b/src/endplay/dealer/constraint.py
@@ -187,6 +187,8 @@ class ConstraintInterpreter:
             return self._fn_hascard(node, deal)
         elif node.value == "imp" or node.value == "imps":
             return self._fn_imps(node, deal)
+        elif node.value == "if":
+            return self._fn_if(node, deal)
         else:
             raise ValueError(f"Unknown function {node.value}")
 


### PR DESCRIPTION
The ternary operator in dealer scripts is implemented as an `if` function internally, which had an implementation but was missing from `_dispatch_function` meaning that any use of the ternary operator raised an error when encountered in a script.

This adds a clause dispatching the `if` function correctly.