### PR TITLE
Build on more platforms

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* pp39-* pp310-*"
-          CIBW_SKIP: "pp*-win* pp*-macos* pp*-linux_aarch64"
+          CIBW_SKIP: "pp*-win* pp*-macos* pp*-manylinux_aarch64"
           CIBW_ARCHS: auto64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-* pp39-* pp310-*"
-          CIBW_SKIP: "pp*-win* pp*-macos*"
+          CIBW_SKIP: "pp*-win* pp*-macos* pp*-linux_aarch64"
           CIBW_ARCHS: auto64
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -39,8 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: pipx install black isort
-      - name: Check import sorting
-        run: isort --tc --profile black --check-only .
+        run: pipx install poetry
+      - name: Install endplay
+        run: poetry install
+      - name: Check formatting
+        run: make format
       - name: Check black formatting
-        run: black --check .
+        run: poetry run black --check .

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Install dependencies
         run: pipx install poetry
       - name: Install endplay

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ TestResults/
 startup.py
 runfile
 src/dump.txt
+
+# macos file
+.DS_STORE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "endplay"
-version = "0.5.11"
+version = "0.5.12"
 description = "A suite of tools for generation and analysis of bridge deals"
 license = "MIT"
 authors = ["Dominic Price <dominicprice@outlook.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ keywords = [
     "deal",
     "dealer"
 ]
+include = [
+  { path = "libs", format = "sdist" }
+]
 
 [tool.poetry.urls]
 "Homepage" = "https://github.com/dominicprice/endplay"

--- a/src/endplay/config.py
+++ b/src/endplay/config.py
@@ -13,10 +13,10 @@ __all__ = [
 from contextlib import ContextDecorator
 
 # Packages metadata, used by setuptools etc
-__version__ = "0.5.11"
+__version__ = "0.5.12"
 """Version of the library as a string"""
 
-__version_info__ = (0, 5, 11)
+__version_info__ = (0, 5, 12)
 """Version of the library as a tuple of integers"""
 
 __author__ = "Dominic Price"

--- a/src/endplay/evaluate/__init__.py
+++ b/src/endplay/evaluate/__init__.py
@@ -292,7 +292,12 @@ def cccc(hand: Union[Hand, SuitHolding]) -> float:
 
 
 def quality(hand: SuitHolding) -> float:
-    "Uses the quality algorithm (from the October 1982 issue of Bridge World magazine)"
+    """
+    Uses the quality algorithm (from the October 1982 issue of Bridge World magazine).
+    I can't find an implementation of this algorithm on the internet, and haven't yet
+    looked at buying a copy of the magazine, but this is an algorithm supported by the
+    original dealer so it is stubbed out here for a possible future implementation.
+    """
     raise NotImplementedError
 
 


### PR DESCRIPTION
Try to increase the number of platforms which we have prebuilt wheels for:

- Github actions now has an ARM based linux image
- The `macos-latest` image is an apple silicon based runner, also include the `macos-13` image to have an intel-based mac image